### PR TITLE
Problem: (CRO-196) Latest rand doesn't compile with client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,12 @@ sgx = []
 sgx_tstd = { rev = "v1.0.8", git = "https://github.com/baidu/rust-sgx-sdk.git" }
 
 [dev-dependencies]
-rand = "0.6"
-rand_core = "0.4"
+rand = "0.7"
+rand_core = "0.5"
 serde_test = "1.0"
 
 [dependencies.rand]
-version = "0.6"
+version = "0.7"
 optional = true
 default-features = false
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -436,7 +436,7 @@ mod test {
     use super::{PublicKey, SecretKey};
     use super::super::constants;
 
-    use rand::{Error, ErrorKind, RngCore, thread_rng};
+    use rand::{Error, RngCore, thread_rng};
     use rand_core::impls;
     use std::iter;
     use std::str::FromStr;
@@ -575,7 +575,7 @@ mod test {
                 self.next_u32() as u64
             }
             fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), Error> {
-                Err(Error::new(ErrorKind::Unavailable, "not implemented"))
+                Err(Error::new("not implemented"))
             }
 
             fn fill_bytes(&mut self, dest: &mut [u8]) {
@@ -655,7 +655,7 @@ mod test {
                 self.next_u32() as u64
             }
             fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), Error> {
-                Err(Error::new(ErrorKind::Unavailable, "not implemented"))
+                Err(Error::new("not implemented"))
             }
 
             fn fill_bytes(&mut self, dest: &mut [u8]) {


### PR DESCRIPTION
Solution: There are two parts to the solution

- Update `rand` in `secp` crate
- Update `rand` in `chain` crate

This pull request is for the first part of the solution.