### PR TITLE
Problem: (CRO-489) client-common fails to compile with zeroize 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,6 @@ version = "1.0"
 optional = true
 
 [dependencies.zeroize]
-version = "0.10"
+version = "1.0"
 optional = true
 default-features = false


### PR DESCRIPTION
Solution: Changed zeroize to 1.0 in secp crate